### PR TITLE
feat: fix location display

### DIFF
--- a/client/src/components/SearchBar/searchBar.tsx
+++ b/client/src/components/SearchBar/searchBar.tsx
@@ -42,7 +42,7 @@ const SearchBar = ({onSearch, formattedLocation}: Props) => {
         axios.get(`http://localhost:4000/api/weather/${location}`)
         .then(res => {
             handleUpdate(res.data)
-            setDisplayLocation(res.data.timezone)
+            setDisplayLocation(res.data.location)
             console.log(res)
         })    
     }

--- a/server/index.controller.ts
+++ b/server/index.controller.ts
@@ -1,5 +1,6 @@
-import { Request, response, Response } from "express";
+import { Request, Response } from "express";
 import axios from "axios";
+import { json } from "stream/consumers";
 
 require('dotenv').config()
 
@@ -16,7 +17,8 @@ const getWeatherData = (req: Request, res: Response) => {
     formattedAddress = r.data.results[0].formatted_address;
     axios.get(`https://api.openweathermap.org/data/2.5/onecall?lat=${lat}&lon=${lon}&exclude=hourly,minutely&units=metric&appid=${process.env.WEATHER_API_KEY}`)
     .then(r => {
-      res.status(200).json(r.data)
+      var weatherInfo = Object.assign(r.data , {location: formattedAddress})
+      res.status(200).json(weatherInfo)
     })
     .catch(err => {
       console.log(err)

--- a/server/index.controller.ts
+++ b/server/index.controller.ts
@@ -17,7 +17,7 @@ const getWeatherData = (req: Request, res: Response) => {
     formattedAddress = r.data.results[0].formatted_address;
     axios.get(`https://api.openweathermap.org/data/2.5/onecall?lat=${lat}&lon=${lon}&exclude=hourly,minutely&units=metric&appid=${process.env.WEATHER_API_KEY}`)
     .then(r => {
-      var weatherInfo = Object.assign(r.data , {location: formattedAddress})
+      const weatherInfo = Object.assign(r.data , {location: formattedAddress})
       res.status(200).json(weatherInfo)
     })
     .catch(err => {


### PR DESCRIPTION
# Formatted location display! 📍

## What was the issue?
- After the switch to using a backend API proxy, we could not send back the Google geocode formatted address.
- On the client it was just displaying the timezone e.g. `Europe/Paris`

## What has been shipped?
- The screen now displays the formatted location, returned back from the google API. 
- This has been achieved with appending the Google formatted location to our res.data from the OpenWeather API.
- The appending has been done like so: `const weatherInfo = Object.assign(r.data , {location: formattedAddress})`
- Source: https://www.delftstack.com/howto/javascript/javascript-append-to-object/#use-the-object-assign-method-to-append-elements-to-objects-in-javascript

## How does it look?

![image](https://user-images.githubusercontent.com/18235528/152866303-22ae4455-75d4-443f-920f-c92122b05ad1.png)
