### PR TITLE
feat: Input validation, GCP API removed

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -7663,6 +7663,11 @@
         "object.assign": "^4.1.2"
       }
     },
+    "keymaster": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/keymaster/-/keymaster-1.6.2.tgz",
+      "integrity": "sha1-4a5U0OqUiPn2C2a2aPAumhlGxus="
+    },
     "kind-of": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
@@ -9432,6 +9437,14 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+    },
+    "react-popup": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/react-popup/-/react-popup-0.10.0.tgz",
+      "integrity": "sha512-NPO65MsAznv/JaP3MDz3DAqKJsA8fEcW5ttzTj6wGXtjPi0qDeB+f+hf4IbMcVrlJ2ZG4uHEdgL6B5QP/AGv3Q==",
+      "requires": {
+        "keymaster": "^1.6.2"
+      }
     },
     "react-refresh": {
       "version": "0.11.0",

--- a/client/package.json
+++ b/client/package.json
@@ -18,6 +18,7 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-icons": "^4.3.1",
+    "react-popup": "^0.10.0",
     "react-scripts": "5.0.0",
     "typescript": "^4.5.5",
     "web-vitals": "^2.1.3"

--- a/client/src/components/SearchBar/searchBar.tsx
+++ b/client/src/components/SearchBar/searchBar.tsx
@@ -38,6 +38,7 @@ const SearchBar = ({onSearch, formattedLocation}: Props) => {
 
     const handleSubmit = (e: React.SyntheticEvent<HTMLFormElement>) => {
         e.preventDefault()
+        
         let found: boolean = false;
 
         // Attempting to check if the location submitted matches the data in the example JSON.

--- a/client/src/components/SearchBar/searchBar.tsx
+++ b/client/src/components/SearchBar/searchBar.tsx
@@ -38,13 +38,20 @@ const SearchBar = ({onSearch, formattedLocation}: Props) => {
 
     const handleSubmit = (e: React.SyntheticEvent<HTMLFormElement>) => {
         e.preventDefault()
-        // Calling our backend express server to get data  
-        axios.get(`http://localhost:4000/api/weather/${location}`)
-        .then(res => {
-            handleUpdate(res.data)
-            setDisplayLocation(res.data.location)
-            console.log(res)
-        })    
+        // check if location is somewhere in the suggestions
+        suggestedLocations.forEach((element) => {
+            if (element === location) {
+                axios.get(`http://localhost:4000/api/weather/${location}`)
+                .then(res => {
+                    handleUpdate(res.data)
+                    setDisplayLocation(res.data.location)
+                    console.log(res)
+                    return
+                }) 
+            }
+        })
+
+        alert('This location is invalid breh')           
     }
 
     const setSuggestions = (loc: string) => {

--- a/client/src/components/SearchBar/searchBar.tsx
+++ b/client/src/components/SearchBar/searchBar.tsx
@@ -38,22 +38,25 @@ const SearchBar = ({onSearch, formattedLocation}: Props) => {
 
     const handleSubmit = (e: React.SyntheticEvent<HTMLFormElement>) => {
         e.preventDefault()
-        // check if location is somewhere in the suggestions
-        let suggestions: string[] = []
+        let found: boolean = false;
+
         for (let j = 0; j < cities.length; j++){
-            const x: string = cities[j].name
-            const y: string = cities[j].country
-        
-            if (x +', ' + y === location) {
+            if (cities[j].name +', ' + cities[j].country === location) {
+                found = true;
+                break;
+        }}
+
+        if (found) {
             axios.get(`http://localhost:4000/api/weather/${location}`)
             .then(res => {
                 handleUpdate(res.data)
                 setDisplayLocation(res.data.location)
                 console.log(res)
-                return
             }) 
-        }}
-        alert('Wrong location breh')
+        }
+        if (!found) {
+            alert('Please choose a location from the drop-down menu.')
+        }
     }
 
     const setSuggestions = (loc: string) => {

--- a/client/src/components/SearchBar/searchBar.tsx
+++ b/client/src/components/SearchBar/searchBar.tsx
@@ -39,19 +39,21 @@ const SearchBar = ({onSearch, formattedLocation}: Props) => {
     const handleSubmit = (e: React.SyntheticEvent<HTMLFormElement>) => {
         e.preventDefault()
         // check if location is somewhere in the suggestions
-        suggestedLocations.forEach((element) => {
-            if (element === location) {
-                axios.get(`http://localhost:4000/api/weather/${location}`)
-                .then(res => {
-                    handleUpdate(res.data)
-                    setDisplayLocation(res.data.location)
-                    console.log(res)
-                    return
-                }) 
-            }
-        })
-
-        alert('This location is invalid breh')           
+        let suggestions: string[] = []
+        for (let j = 0; j < cities.length; j++){
+            const x: string = cities[j].name
+            const y: string = cities[j].country
+        
+            if (x +', ' + y === location) {
+            axios.get(`http://localhost:4000/api/weather/${location}`)
+            .then(res => {
+                handleUpdate(res.data)
+                setDisplayLocation(res.data.location)
+                console.log(res)
+                return
+            }) 
+        }}
+        alert('Wrong location breh')
     }
 
     const setSuggestions = (loc: string) => {

--- a/client/src/components/SearchBar/searchBar.tsx
+++ b/client/src/components/SearchBar/searchBar.tsx
@@ -40,12 +40,15 @@ const SearchBar = ({onSearch, formattedLocation}: Props) => {
         e.preventDefault()
         let found: boolean = false;
 
+        // Attempting to check if the location submitted matches the data in the example JSON.
+        // If there is a match, then exit the loop, and assign 'found' to true.
         for (let j = 0; j < cities.length; j++){
             if (cities[j].name +', ' + cities[j].country === location) {
                 found = true;
                 break;
         }}
 
+        // If 'found' is true, then call the API with the location data submitted.
         if (found) {
             axios.get(`http://localhost:4000/api/weather/${location}`)
             .then(res => {
@@ -54,6 +57,8 @@ const SearchBar = ({onSearch, formattedLocation}: Props) => {
                 console.log(res)
             }) 
         }
+
+        // If 'found' is false, then do not call the API, and alert the user that they need to re-submit
         if (!found) {
             alert('Please choose a location from the drop-down menu.')
         }

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -78,7 +78,7 @@
 
     /* Type Checking */
     "strict": true,                                      /* Enable all strict type-checking options. */
-    "noImplicitAny": true,                            /* Enable error reporting for expressions and declarations with an implied `any` type.. */
+    "noImplicitAny": false,                            /* Enable error reporting for expressions and declarations with an implied `any` type.. */
     // "strictNullChecks": true,                         /* When type checking, take into account `null` and `undefined`. */
     // "strictFunctionTypes": true,                      /* When assigning functions, check to ensure parameters and the return values are subtype-compatible. */
     // "strictBindCallApply": true,                      /* Check that the arguments for `bind`, `call`, and `apply` methods match the original function. */

--- a/server/index.controller.ts
+++ b/server/index.controller.ts
@@ -1,20 +1,22 @@
 import { Request, Response } from "express";
 import axios from "axios";
-import { json } from "stream/consumers";
-
+import cities from 'cities.json'
 require('dotenv').config()
 
 const getWeatherData = (req: Request, res: Response) => {
 
   let location: string = req.params.location;
-  let formattedAddress: string;
-  let lat: number;
-  let lon: number;
-  axios.get(`https://maps.googleapis.com/maps/api/geocode/json?address=${location}&key=${process.env.GCP_API_KEY}`)
-  .then(r => {
-    lat = r.data.results[0].geometry.location.lat
-    lon = r.data.results[0].geometry.location.lng
-    formattedAddress = r.data.results[0].formatted_address;
+  let formattedAddress: string = location
+  let lat: string;
+  let lon: string;
+
+  for (let j = 0; j < cities.length; j++) {
+    if (cities[j].name +', ' + cities[j].country === location) {
+      lat = cities[j].lat
+      lon = cities[j].lng
+      break;
+  }}
+    
     axios.get(`https://api.openweathermap.org/data/2.5/onecall?lat=${lat}&lon=${lon}&exclude=hourly,minutely&units=metric&appid=${process.env.WEATHER_API_KEY}`)
     .then(r => {
       const weatherInfo = Object.assign(r.data , {location: formattedAddress})
@@ -23,9 +25,6 @@ const getWeatherData = (req: Request, res: Response) => {
     .catch(err => {
       console.log(err)
     })
-  }).catch(err => {
-    console.log(err)
-  })
 }
 
 

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1408,6 +1408,11 @@
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
       "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ=="
     },
+    "cities.json": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/cities.json/-/cities.json-1.1.5.tgz",
+      "integrity": "sha512-BKge3FmYfYOtN3tBaLfN9QvB7M5dDyjen3aFOn6XwgNASvLDhWTJazAtCvbpDWlpM6YWZXh4TUTsgxOn/n6MbA=="
+    },
     "cjs-module-lexer": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.2.tgz",

--- a/server/package.json
+++ b/server/package.json
@@ -31,6 +31,7 @@
   "license": "ISC",
   "dependencies": {
     "axios": "^0.25.0",
+    "cities.json": "^1.1.5",
     "cors": "^2.8.5",
     "dotenv": "^15.0.0",
     "express": "^4.17.2",

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -2,8 +2,9 @@
     "compilerOptions": {
         "module": "commonjs",
         "esModuleInterop": true,
+        "resolveJsonModule": true,
         "target": "es6",
-        "noImplicitAny": true,
+        "noImplicitAny": false,
         "moduleResolution": "node",
         "sourceMap": true,
         "outDir": "dist",


### PR DESCRIPTION
# Input Validation enforced, and GCP API removed! 📝

## What was the issue? 
- The GCP geocoding API was costing us money to make requests, but we already data a JSON full of geocoded locations.
- The user could put any data they wanted into the input form, which meant it was impossible to use our JSON.

## What was the solution? 
- A simple little check to see if the form entry was able to be found in the JSON, quite like we did already with the suggestions drop-down.
- Use of the `alert()` function which would stop the user from making an API request with duff data.
- Changes server-side, removing the GCP API and implementing a check to pull the lat and lon data.

## Demo! 🚦
![input-validation-demo](https://user-images.githubusercontent.com/18235528/153295680-2c738e20-b690-49dd-b05c-7e586a14d449.gif)


### Future improvements... 💭
- The lat & lon could be directly sent over from the client as it already has full access to the JSON file.
- The API controller server-side could adjust the data its taking in so that we dont need to do that extra check to pull the data.