### PR TITLE
feat: Client side resolution of geocoded location

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -6,14 +6,10 @@ import defaultweather from './exampleData.json';
 import SunPosition from './components/DisplayWeather/SunPosition/SunPosition'
 import ErrorBoundary from './components/ErrorBoundary/ErrorBoundary'
 
-// const { DateTime } = require("luxon");
-
 function App() {
   
-  // const defaultweather = './defaultweather.json'
-  // We manage state here as we'll get it in SearchBar
   const [weatherInfo, setWeatherInfo] = useState(defaultweather)
-  const [displayLocation, setDisplayLocation] = useState('Monaco')
+  const [displayLocation, setDisplayLocation] = useState('Monaco, MC')
   const [isDay, setIsDay] = useState<boolean>(true);
 
   return (

--- a/client/src/components/DisplayWeather/CurrentDayWeather/CurrentDayWeather.tsx
+++ b/client/src/components/DisplayWeather/CurrentDayWeather/CurrentDayWeather.tsx
@@ -25,13 +25,6 @@ const DisplayCurrent = (props: Props)=> {
                             <p className="measurementTitle">Feels like</p>
                             <p className="measurementValue">{props.currentDay.feels_like.toFixed(0)}C</p>
                     </div>
-                    {/* Boxing this div for now since its already there in the forecast. */}
-                    {/* <div className="current-weather">
-                            <p>Max</p>
-                            <h3>{props.currentWeather.temp.max.toFixed(0)}C</h3>
-                            <p>Min</p>
-                            <h3>{props.currentWeather.temp.min.toFixed(0)}C</h3>
-                    </div> */}
                     <div className="current-weather">
                             <p className="measurementTitle">Wind speed</p>
                             <p className="measurementValue">{props.currentWeather.wind_speed.toFixed(0)}mph</p>

--- a/client/src/components/SearchBar/searchBar.tsx
+++ b/client/src/components/SearchBar/searchBar.tsx
@@ -40,12 +40,16 @@ const SearchBar = ({onSearch, formattedLocation}: Props) => {
         e.preventDefault()
         
         let found: boolean = false;
-
+        let lat: string;
+        let lon: string;
         // Attempting to check if the location submitted matches the data in the example JSON.
         // If there is a match, then exit the loop, and assign 'found' to true.
         for (let j = 0; j < cities.length; j++){
             if (cities[j].name +', ' + cities[j].country === location) {
                 found = true;
+                lat = cities[j].lat;
+                lon = cities[j].lng;
+                console.log(lat + ' ' + lon)
                 break;
         }}
 

--- a/client/src/components/SearchBar/searchBar.tsx
+++ b/client/src/components/SearchBar/searchBar.tsx
@@ -14,12 +14,12 @@ type Props = {
 
 const SearchBar = ({onSearch, formattedLocation}: Props) => {
 
-    const [location, setLocation] = useState<string>('Monaco')
+    const [location, setLocation] = useState<string>('Monaco, MC')
     const [suggestedLocations, setSuggestedLocations] = useState<string[]>([cities[1000].name])
     
     // Loads Monaco weather on page load.
     useEffect(() => {
-        axios.get(`http://localhost:4000/api/weather/Monaco`)
+        axios.get(`http://localhost:4000/api/weather/43.73333/7.41667`)
         .then(res => {
             handleUpdate(res.data)
             console.log(res)
@@ -40,8 +40,8 @@ const SearchBar = ({onSearch, formattedLocation}: Props) => {
         e.preventDefault()
         
         let found: boolean = false;
-        let lat: string;
-        let lon: string;
+        let lat!: string;
+        let lon!: string;
         // Attempting to check if the location submitted matches the data in the example JSON.
         // If there is a match, then exit the loop, and assign 'found' to true.
         for (let j = 0; j < cities.length; j++){
@@ -55,11 +55,10 @@ const SearchBar = ({onSearch, formattedLocation}: Props) => {
 
         // If 'found' is true, then call the API with the location data submitted.
         if (found) {
-            axios.get(`http://localhost:4000/api/weather/${location}`)
+            axios.get(`http://localhost:4000/api/weather/${lat}/${lon}`)
             .then(res => {
                 handleUpdate(res.data)
-                setDisplayLocation(res.data.location)
-                console.log(res)
+                setDisplayLocation(location)
             }) 
         }
 

--- a/server/index.controller.ts
+++ b/server/index.controller.ts
@@ -8,13 +8,6 @@ const getWeatherData = (req: Request, res: Response) => {
   let formattedAddress: string = location
   let lat: string = req.params.lat
   let lon: string = req.params.lon
-
-  // for (let j = 0; j < cities.length; j++) {
-  //   if (cities[j].name +', ' + cities[j].country === location) {
-  //     lat = cities[j].lat
-  //     lon = cities[j].lng
-  //     break;
-  // }}
     
     axios.get(`https://api.openweathermap.org/data/2.5/onecall?lat=${lat}&lon=${lon}&exclude=hourly,minutely&units=metric&appid=${process.env.WEATHER_API_KEY}`)
     .then(r => {

--- a/server/index.controller.ts
+++ b/server/index.controller.ts
@@ -1,21 +1,20 @@
 import { Request, Response } from "express";
 import axios from "axios";
-import cities from 'cities.json'
 require('dotenv').config()
 
 const getWeatherData = (req: Request, res: Response) => {
 
-  let location: string = req.params.location;
+  let location: string = req.params.location
   let formattedAddress: string = location
-  let lat: string;
-  let lon: string;
+  let lat: string = req.params.lat
+  let lon: string = req.params.lon
 
-  for (let j = 0; j < cities.length; j++) {
-    if (cities[j].name +', ' + cities[j].country === location) {
-      lat = cities[j].lat
-      lon = cities[j].lng
-      break;
-  }}
+  // for (let j = 0; j < cities.length; j++) {
+  //   if (cities[j].name +', ' + cities[j].country === location) {
+  //     lat = cities[j].lat
+  //     lon = cities[j].lng
+  //     break;
+  // }}
     
     axios.get(`https://api.openweathermap.org/data/2.5/onecall?lat=${lat}&lon=${lon}&exclude=hourly,minutely&units=metric&appid=${process.env.WEATHER_API_KEY}`)
     .then(r => {

--- a/server/index.ts
+++ b/server/index.ts
@@ -6,6 +6,6 @@ const app = express()
 
 app.use(cors({credentials: true, origin: 'http://localhost:3000'}));
 
-app.get('/api/weather/:location', controller.getWeatherData)
+app.get('/api/weather/:lat/:lon', controller.getWeatherData)
 
 export default app;


### PR DESCRIPTION
# Client side resolution of geocoded location! 🌎

## What was the problem? 
- On the client side, we were pulling the country and city straight from the cities.json.
- On the server side, we would check that *same* json object to get the latitude and longitude for that location


## What was the solution?
- Removal of server side handling of cities.json.
- New API parameters to take the lat and lon directly from the client: `/api/weather/:lat/:lon`
- Client side lookup of the lat and lon straight from the cities.json file.
- Client now calling the new api e.g. `axios.get(http://localhost:4000/api/weather/43.73333/7.41667)`